### PR TITLE
Fix wierd color behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,29 +53,6 @@ if [ -f ~/bash_files/bash_init.sh ]; then
 fi
 ```
 
-### Fix weird behaviour
-
-```bash
-"--> If someone knows how to fix this in a proper way,
-please create a pull request, thx."
-```
-
-For some to me yet not understood reason it seems to be necessary to alter the following section in .bashrc in order to make colours work flawlessly when the files reside in a separate dir:
-
-```bash
-if [ "$color_prompt" = yes ]; then
-    #PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-    . ~/bash_files/bash_prompt.sh #<-- Add this and comment out the line before with the prompt
-else
-    #PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
-    . ~/bash_files/bash_prompt.sh #<-- Add this and comment out the line before with the prompt
-fi
-unset color_prompt force_color_prompt
-
-```
-
-
-
 ## File structure
 
 The files live in ~/bash_files/

--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -8,8 +8,12 @@
 #                                                                              #
 ################################################################################
 
+if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
+elif infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
+fi
+
 # List all colors
-# ( x=`tput op` y=`printf %$((${COLUMNS}-6))s`;for i in {0..256};do o=00$i;echo -e ${o:${#o}-3:3} `tput setaf $i;tput setab $i`${y// /=}$x;done; ) 
+# ( x=`tput op` y=`printf %$((${COLUMNS}-6))s`;for i in {0..256};do o=00$i;echo -e ${o:${#o}-3:3} `tput setaf $i;tput setab $i`${y// /=}$x;done; )
 
 
 NORMAL=$(tput sgr0) # Reset text format to the terminal's default

--- a/bash_prompt.sh
+++ b/bash_prompt.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
-fi
-
-
 function parse_git_dirty() {
   [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit (working directory clean)" ]] && echo "*"
 }
@@ -14,4 +9,3 @@ function parse_git_branch() {
 }
 
 PS1="\[$GREY\]\t\n\[$RED\]\u\[$GREY\]@\[$ORANGE\]\h \[$YELLOW\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\] \[$RESET\]"
-


### PR DESCRIPTION
The `$TERM` was set to 256 after the color variables were initialized, instead of before, so there was only 8 colors available in `tput setaf`.